### PR TITLE
Add Airflow DAG to export mood data from MongoDB to JSON file

### DIFF
--- a/Dockerfile.airflow
+++ b/Dockerfile.airflow
@@ -1,0 +1,5 @@
+FROM apache/airflow:2.9.1
+
+COPY airflow/requirements.txt /requirements.txt
+
+RUN pip install --no-cache-dir -r /requirements.txt

--- a/airflow/dags/mongo_export_dag.py
+++ b/airflow/dags/mongo_export_dag.py
@@ -1,0 +1,47 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+from pymongo import MongoClient
+import json
+import os
+
+
+# Since DateTime type is not JSON Serilaizable we will make it string
+def convert_datetime(obj):
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    return obj
+
+
+def export_mongo_to_file():
+    print("Starting Mongo export...")  # <-- This should appear in logs
+    client = MongoClient("mongodb://mongo:27017/")
+    db = client["city_mood"]
+    collection = db["mood_events"]
+    records = list(collection.find({}, {"_id": 0}))
+    print(f"Exporting {len(records)} records...")  # <-- This too
+
+    os.makedirs("/opt/airflow/mounted_exports", exist_ok=True)
+    with open("/opt/airflow/mounted_exports/mood_export.json", "w") as f:
+        json.dump(records, f, indent=2, default=convert_datetime)
+
+    print("Export finished.")
+    client.close()
+
+
+default_args = {
+    "start_date": datetime(2025, 3, 25),
+    "catchup": False
+}
+
+with DAG(
+        "mongo_to_storage",
+        schedule_interval="@daily",
+        default_args=default_args,
+        description="Export mood data from MongoDB to file (then to S3/PostgreSQL)",
+        tags=["mood-tracker"],
+) as dag:
+    export_task = PythonOperator(
+        task_id="export_mongo_to_file",
+        python_callable=export_mongo_to_file
+    )

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -1,0 +1,2 @@
+pymongo
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,5 +66,74 @@ services:
     networks:
       - datamasterylab
 
+  airflow-webserver:
+    image: apache/airflow:2.9.1
+    container_name: airflow-webserver
+    restart: always
+    depends_on:
+      - airflow-scheduler
+      - postgres
+    build:
+      context: .
+      dockerfile: Dockerfile.airflow
+    environment:
+      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres/airflow
+      - AIRFLOW__CORE__FERNET_KEY=some_fernet_key
+      - AIRFLOW__WEBSERVER__SECRET_KEY=some_secret_key
+      - AIRFLOW__WEBSERVER__WORKERS=2
+      - AIRFLOW__CORE__LOAD_EXAMPLES=False
+      - AIRFLOW__LOGGING__LOGGING_LEVEL=INFO
+    volumes:
+      - ./airflow/dags:/opt/airflow/dags
+      - ./airflow/logs:/opt/airflow/logs
+      - ./airflow/plugins:/opt/airflow/plugins
+      - ./airflow/requirements.txt:/requirements.txt
+      - ./airflow/mounted_exports:/opt/airflow/mounted_exports
+    ports:
+      - "8081:8080"
+    networks:
+      - datamasterylab
+    command: bash -c "pip install -r /requirements.txt && airflow webserver"
+
+  airflow-scheduler:
+    image: apache/airflow:2.9.1
+    container_name: airflow-scheduler
+    restart: always
+    depends_on:
+      - postgres
+    build:
+      context: .
+      dockerfile: Dockerfile.airflow
+    environment:
+      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres/airflow
+      - AIRFLOW__CORE__LOAD_EXAMPLES=False
+      - AIRFLOW__LOGGING__LOGGING_LEVEL=INFO
+    volumes:
+      - ./airflow/dags:/opt/airflow/dags
+      - ./airflow/logs:/opt/airflow/logs
+      - ./airflow/plugins:/opt/airflow/plugins
+      - ./airflow/mounted_exports:/opt/airflow/mounted_exports
+    networks:
+      - datamasterylab
+    command: bash -c "airflow db migrate && airflow scheduler"
+
+  postgres:
+    image: postgres:14
+    container_name: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - datamasterylab
+
+volumes:
+  postgres_data:
+
 networks:
   datamasterylab:


### PR DESCRIPTION
Adds an Airflow DAG that exports mood data from the mood_events MongoDB collection to a mounted JSON file. Useful for daily backups and downstream processing.