### PR TITLE
Add task to delete exported JSON file after S3 and PostgreSQL uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,7 @@ services:
 
 volumes:
   postgres_data:
+  mongo_data:
 
 networks:
   datamasterylab:


### PR DESCRIPTION
This update adds a cleanup task to the DAG that deletes the exported mood data JSON file after it has been successfully uploaded to both S3 and PostgreSQL. Ensures efficient disk usage by preventing data accumulation in the container.
