### PR TITLE
Add daily summary DAG and fix Slack import by updating PYTHONPATH and Docker mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,12 +86,14 @@ services:
       - AIRFLOW__WEBSERVER__WORKERS=2
       - AIRFLOW__CORE__LOAD_EXAMPLES=False
       - AIRFLOW__LOGGING__LOGGING_LEVEL=INFO
+      - PYTHONPATH=/opt/airflow
     volumes:
       - ./my_airflow/dags:/opt/airflow/dags
       - ./my_airflow/logs:/opt/airflow/logs
       - ./my_airflow/plugins:/opt/airflow/plugins
       - ./my_airflow/requirements.txt:/requirements.txt
       - ./my_airflow/mounted_exports:/opt/airflow/mounted_exports
+      - ./my_airflow:/opt/airflow/my_airflow
     ports:
       - "8081:8080"
     env_file:
@@ -114,11 +116,13 @@ services:
       - AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres/airflow
       - AIRFLOW__CORE__LOAD_EXAMPLES=False
       - AIRFLOW__LOGGING__LOGGING_LEVEL=INFO
+      - PYTHONPATH=/opt/airflow
     volumes:
       - ./my_airflow/dags:/opt/airflow/dags
       - ./my_airflow/logs:/opt/airflow/logs
       - ./my_airflow/plugins:/opt/airflow/plugins
       - ./my_airflow/mounted_exports:/opt/airflow/mounted_exports
+      - ./my_airflow:/opt/airflow/my_airflow
     networks:
       - datamasterylab
     env_file:

--- a/my_airflow/dags/daily_summary_report.py
+++ b/my_airflow/dags/daily_summary_report.py
@@ -1,0 +1,70 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime, timedelta
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, date_format, avg, count
+from my_airflow.utils.slack import notify_slack_failure
+
+default_args = {
+    "start_date": datetime(2025, 4, 28),
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+    "depends_on_past": False
+}
+
+
+def summarize_mood_data():
+    spark = SparkSession.builder \
+        .appName("Mood Summary Report") \
+        .config("spark.jars.packages", "org.postgresql:postgresql:42.7.2") \
+        .getOrCreate()
+
+    yesterday = datetime.utcnow().date()
+
+    df = spark.read \
+        .format("jdbc") \
+        .option("url", "jdbc:postgresql://postgres:5432/airflow") \
+        .option("dbtable", "mood_events") \
+        .option("user", "airflow") \
+        .option("password", "airflow") \
+        .option("driver", "org.postgresql.Driver") \
+        .load()
+
+    df = df.withColumn("event_date", date_format("event_time", "yyyy-MM-dd"))
+    df = df.filter(col("event_date") == str(yesterday))
+
+    summary_df = df.groupBy("intersection", "mood").agg(
+        count("*").alias("records_count"),
+        avg("avg_speed").alias("avg_speed"),
+        avg("avg_temp").alias("avg_temp")
+    )
+
+    summary_df.write \
+        .format("jdbc") \
+        .option("url", "jdbc:postgresql://postgres:5432/airflow") \
+        .option("dbtable", "mood_summary") \
+        .option("user", "airflow") \
+        .option("password", "airflow") \
+        .option("driver", "org.postgresql.Driver") \
+        .mode("append") \
+        .save()
+
+    spark.stop()
+
+
+with DAG(
+    dag_id="daily_summary_report",
+    schedule_interval="0 1 * * *",  # Every day at 01:00 AM
+    default_args=default_args,
+    catchup=False,
+    description="Summarize yesterday's mood data by intersection and mood",
+    tags=["mood-tracker", "summary"],
+    on_failure_callback=notify_slack_failure
+) as dag:
+
+    generate_summary = PythonOperator(
+        task_id="summarize_mood_data",
+        python_callable=summarize_mood_data
+    )
+
+    generate_summary

--- a/my_airflow/dags/mongo_to_storage.py
+++ b/my_airflow/dags/mongo_to_storage.py
@@ -6,33 +6,8 @@ from pymongo import MongoClient
 import json
 import os
 from pyspark.sql import SparkSession
-import psycopg2
 import boto3
-import requests
-
-
-def notify_slack_failure(context):
-    webhook_url = os.getenv("SLACK_WEBHOOK_URL")
-    if not webhook_url:
-        print("No Slack webhook configured!")
-        return
-
-    task_instance = context.get('task_instance')
-    dag_id = context.get('dag').dag_id
-    execution_date = context.get('execution_date')
-
-    message = (
-        f":x: *Task Failed!* \n"
-        f"*Task*: `{task_instance.task_id}`\n"
-        f"*Dag*: `{dag_id}`\n"
-        f"*Execution Time*: `{execution_date}`"
-    )
-
-    response = requests.post(webhook_url, json={"text": message})
-
-    if response.status_code != 200:
-        print(f"Failed to send Slack notification: {response.text}")
-
+from my_airflow.utils.slack import notify_slack_failure
 
 def cleanup_mongo_db(export_path="/opt/airflow/mounted_exports/mood_export.json"):
     print("Cleaning up MongoDB and local file...")

--- a/my_airflow/dags/mood_quality_check.py
+++ b/my_airflow/dags/mood_quality_check.py
@@ -3,6 +3,8 @@ from airflow.operators.python import PythonOperator
 from datetime import datetime
 from pymongo import MongoClient
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from my_airflow.utils.slack import notify_slack_failure
+
 
 
 def check_mongo_data():
@@ -50,6 +52,7 @@ with DAG(
     default_args=default_args,
     description="Check mood data quality before exporting",
     tags=["mood-tracker", "quality"],
+    on_failure_callback=notify_slack_failure
 ) as dag:
 
     check_data_task = PythonOperator(

--- a/my_airflow/utils/slack.py
+++ b/my_airflow/utils/slack.py
@@ -1,0 +1,24 @@
+# my_airflow/utils/slack.py
+import os
+import requests
+
+def notify_slack_failure(context):
+    webhook_url = os.getenv("SLACK_WEBHOOK_URL")
+    if not webhook_url:
+        print("No Slack webhook configured!")
+        return
+
+    task_instance = context.get('task_instance')
+    dag_id = context.get('dag').dag_id
+    execution_date = context.get('execution_date')
+
+    message = (
+        f":x: *Task Failed!*\n"
+        f"*Task*: `{task_instance.task_id}`\n"
+        f"*DAG*: `{dag_id}`\n"
+        f"*Execution Time*: `{execution_date}`"
+    )
+
+    response = requests.post(webhook_url, json={"text": message})
+    if response.status_code != 200:
+        print(f"Failed to send Slack notification: {response.text}")

--- a/weather_producer.py
+++ b/weather_producer.py
@@ -47,7 +47,6 @@ while True:
         cw = data["current_weather"]
         # using datetime instead of open-mateo API, since open-mateo sends the same data for the last 15 minutes
         timestamp = datetime.utcnow().replace(second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
-        print(cw)
         payload = {
             "timestamp": timestamp,
             "temp": cw["temperature"],


### PR DESCRIPTION
This PR introduces a new DAG to summarize daily mood data from PostgreSQL. It also enables Slack failure notifications across all DAGs by refactoring the notify_slack_failure function into a shared utility and fixing import issues via Docker volume mounts and PYTHONPATH configuration.